### PR TITLE
continuable records end at column 80

### DIFF
--- a/io/pdb.lisp
+++ b/io/pdb.lisp
@@ -103,7 +103,7 @@
                          :initform '(8 10))
    (field-columns :initarg :field-columns
                   :accessor field-columns
-                  :initform '(10 70))
+                  :initform '(10 80))
    (lines :initarg :lines :accessor lines :initform nil)
    (data :initarg :data :accessor data :initform nil))
   (:documentation "subclass of pdb-record for holding information


### PR DESCRIPTION
Most continuable records (strings and lists) end at column 80 or 79 following the PDB specs. I ended up with incomplete record titles.